### PR TITLE
chore(major): load tokenizer config from files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,16 +11,13 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: [ '1.20', '1.21' ]
 
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: 1.21
       - name: Install dependencies
         run: go get .
       - name: Test with Go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.20', '1.21.x' ]
+        go-version: [ '1.20', '1.21' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anush008/fastembed-go
 
-go 1.21.1
+go 1.21
 
 require (
 	github.com/schollz/progressbar/v3 v3.13.1


### PR DESCRIPTION
Implement loading tokenizer configurations from config files.
Ref: https://github.com/qdrant/fastembed/pull/13