### PR TITLE
readme: fix import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The default embedding supports "query" and "passage" prefixes for the input text
 Run the following Go CLI command in your project directory:
 
 ```bash
-go get -u github.com/Anush008/fastembed-go
+go get -u github.com/anush008/fastembed-go
 ```
 
 ## 📖 Usage


### PR DESCRIPTION
Originally, I got the following error message:

```
$ go get -u github.com/Anush008/fastembed-go
go: downloading github.com/Anush008/fastembed-go v1.0.0
go: github.com/Anush008/fastembed-go@upgrade (v1.0.0) requires github.com/Anush008/fastembed-go@v1.0.0: parsing go.mod:
        module declares its path as: github.com/anush008/fastembed-go
                but was required as: github.com/Anush008/fastembed-go
```